### PR TITLE
Implement adding messages from the Moodle App

### DIFF
--- a/classes/external/add_message.php
+++ b/classes/external/add_message.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_greetings\external;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->libdir . "/externallib.php");
+
+use external_api;
+use external_description;
+use external_function_parameters;
+use external_single_structure;
+use external_value;
+use external_warnings;
+use stdClass;
+
+/**
+ * Add message.
+ *
+ * @package     local_greetings
+ * @copyright   2022 Moodle Pty Ltd. (http://moodle.com)
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class add_message extends external_api {
+
+    /**
+     * Returns the description of the webservice parameters.
+     *
+     * @return external_function_parameters
+     */
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'message' => new external_value(PARAM_RAW, 'Greeting message'),
+        ]);
+    }
+
+    /**
+     * Handle request.
+     *
+     * @param  string $message Greeting message.
+     * @return array Result as defined in execute_returns.
+     */
+    public static function execute($message) {
+        // Validate request.
+        $validatedparams = self::validate_parameters(self::execute_parameters(), compact('message'));
+        [$message] = array_values($validatedparams);
+
+        $message = trim($message);
+
+        if (empty($message)) {
+            return [
+                'warnings' => [[
+                    'warningcode' => 'emptymessage',
+                    'message' => get_string('emptymessage', 'local_greetings')
+                ]],
+            ];
+        }
+
+        // Add message.
+        global $DB, $USER;
+
+        $record = new stdClass();
+        $record->message = $message;
+        $record->timecreated = time();
+        $record->userid = $USER->id;
+
+        $DB->insert_record('local_greetings_messages', $record);
+
+        return ['warnings' => []];
+    }
+
+    /**
+     * Returns the description of the webservice response.
+     *
+     * @return external_description
+     */
+    public static function execute_returns(): external_description {
+        return new external_single_structure([
+            'warnings' => new external_warnings(),
+        ]);
+    }
+
+}

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -73,7 +73,23 @@ class mobile {
             ],
             'javascript' => file_get_contents(__DIR__ . '/../../js/mobile/view_greetings_list.js'),
         ];
+    }
 
+    public static function mobile_add_message() {
+        global $OUTPUT;
+
+        require_capability('local/greetings:postmessages', context_system::instance());
+
+        return [
+            'templates' => [
+                [
+                    'id' => 'main',
+                    'html' => $OUTPUT->render_from_template('local_greetings/mobile_add_message', []),
+                ],
+            ],
+            'otherdata' => ['message' => ''],
+            'javascript' => file_get_contents(__DIR__ . '/../../js/mobile/add_message.js'),
+        ];
     }
 
 }

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -60,6 +60,7 @@ class mobile {
         }
 
         $data = [
+            'allowposting' => has_capability('local/greetings:postmessages', $context),
             'messages' => array_values($messages),
         ];
 
@@ -70,6 +71,7 @@ class mobile {
                     'html' => $OUTPUT->render_from_template('local_greetings/mobile_view_greetings_list', $data),
                 ],
             ],
+            'javascript' => file_get_contents(__DIR__ . '/../../js/mobile/view_greetings_list.js'),
         ];
 
     }

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -40,11 +40,15 @@ $addons = [
             ],
         ],
         'lang' => [
+            ['addmessage', 'local_greetings'],
+            ['greetings:postmessages', 'local_greetings'],
             ['greetings', 'local_greetings'],
             ['hello', 'local_greetings'],
             ['postedby', 'local_greetings'],
             ['nomessages', 'local_greetings'],
+            ['yourmessage', 'local_greetings'],
             ['messages', 'message'],
+            ['submit', 'moodle'],
         ],
     ],
 ];

--- a/db/services.php
+++ b/db/services.php
@@ -1,0 +1,33 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * @package     local_greetings
+ * @copyright   2022 Moodle Pty Ltd. (http://moodle.com)
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$functions = [
+    'local_greetings_add_message' => [
+        'classname'     => 'local_greetings\external\add_message',
+        'methodname'    => 'execute',
+        'classpath'     => 'local/greetings/classes/external/add_message.php',
+        'description'   => 'Submit new message',
+        'type'          => 'write',
+        'capabilities'  => 'local/greetings:postmessages',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+];

--- a/js/mobile/add_message.js
+++ b/js/mobile/add_message.js
@@ -13,7 +13,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
-const translate = key => this.TranslateService.instant(`plugin.local_greetings.${key}`);
-const observer = this.CoreEventsProvider.on('local_greetings:messages-updated', () => this.refreshContent());
-
-this.ngOnDestroy = () => observer.off();
+this.messagesUpdated = () => this.CoreEventsProvider.trigger('local_greetings:messages-updated');

--- a/js/mobile/view_greetings_list.js
+++ b/js/mobile/view_greetings_list.js
@@ -1,0 +1,44 @@
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+const translate = key => this.TranslateService.instant(`plugin.local_greetings.${key}`);
+
+this.addMessage = () => {
+    const alertOptions = {
+        header: translate('addmessage'),
+        inputs: [{
+            name: 'message',
+            type: 'textarea',
+            placeholder: translate('yourmessage'),
+        }],
+        buttons: [{
+            text: translate('submit'),
+            handler: ({ message }) => {
+                if (!message) {
+                    return;
+                }
+
+                this.CoreSitesProvider
+                    .getCurrentSite()
+                    .write('local_greetings_add_message', { message })
+                    .then(() => this.refreshContent());
+            },
+        }],
+    };
+
+    this.AlertController
+        .create(alertOptions)
+        .then(alert => alert.present());
+};

--- a/lang/en/local_greetings.php
+++ b/lang/en/local_greetings.php
@@ -25,6 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+$string['addmessage'] = 'Add message';
+$string['emptymessage'] = 'Message should not be empty';
 $string['pluginname'] = 'Greetings';
 $string['greetinguser'] = 'Greetings, user.';
 $string['greetingloggedinuser'] = 'Greetings, {$a}.';

--- a/templates/mobile_add_message.mustache
+++ b/templates/mobile_add_message.mustache
@@ -1,0 +1,15 @@
+{{=<% %>=}}
+<ion-content>
+    <ion-list>
+        <ion-item>
+            <ion-label position="floating">
+                <%#str%> yourmessage, local_greetings <%/str%>
+            </ion-label>
+            <ion-textarea [(ngModel)]="CONTENT_OTHERDATA.message"></ion-textarea>
+        </ion-item>
+        <ion-button class="ion-margin" expand="block" core-site-plugins-call-ws name="local_greetings_add_message" useOtherDataForWS
+            goBackOnSuccess="true" (onSuccess)="messagesUpdated()">
+            <%#str%> submit <%/str%>
+        </ion-button>
+    </ion-list>
+</ion-content>

--- a/templates/mobile_view_greetings_list.mustache
+++ b/templates/mobile_view_greetings_list.mustache
@@ -18,3 +18,12 @@
 <%/messages%>
 
 </div>
+
+<%#allowposting%>
+<ion-fab core-fab vertical="bottom" horizontal="end" slot="fixed" (click)="addMessage()"
+    [attr.aria-label]="'plugin.local_greetings.greetings:postmessages' | translate">
+    <ion-fab-button>
+        <ion-icon name="add"></ion-icon>
+    </ion-fab-button>
+</ion-fab>
+<%/allowposting%>

--- a/templates/mobile_view_greetings_list.mustache
+++ b/templates/mobile_view_greetings_list.mustache
@@ -20,7 +20,8 @@
 </div>
 
 <%#allowposting%>
-<ion-fab core-fab vertical="bottom" horizontal="end" slot="fixed" (click)="addMessage()"
+<ion-fab core-fab vertical="bottom" horizontal="end" slot="fixed"
+    core-site-plugins-new-content method="mobile_add_message" title="<%#str%> addmessage, local_greetings <%/str%>"
     [attr.aria-label]="'plugin.local_greetings.greetings:postmessages' | translate">
     <ion-fab-button>
         <ion-icon name="add"></ion-icon>


### PR DESCRIPTION
This PR contains two commits to implement this feature following different approaches. The first one is simpler, using a prompt alert to get input from users. The second one is using a new page with a form, which would be more common for actions requiring more complex inputs. I'm adding both in case it's interesting to show both approaches in the course.